### PR TITLE
use original prop names

### DIFF
--- a/bchrpc/proxy/gw.go
+++ b/bchrpc/proxy/gw.go
@@ -31,6 +31,7 @@ func serveHTTP(ctx context.Context) error {
 	// Note: Make sure the gRPC server is running properly and accessible
 	grpcGateway := runtime.NewServeMux(
 		runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{
+			OrigName:     true,
 			EmitDefaults: true,
 		}),
 	)


### PR DESCRIPTION
this PR changed some variable names https://github.com/simpleledgerinc/bchd/pull/8

it then used json tags for names in `bchrpc.pb.go`
`name=cash_addr,json=cashAddr,proto3`

Now by setting OriginalNames: true we use the previous `name` tags again: https://godoc.org/github.com/golang/protobuf/jsonpb#Marshaler